### PR TITLE
Add HTTP 302 to redirected status codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function follow (u, ms) {
     console.log(chalk.green('[' + res.statusCode + '] ') + chalk.gray(opts.method) + ' ' + u + chalk.cyan(' (' + diff + ' ms)'))
     switch (res.statusCode) {
       case 301:
+      case 302:
       case 303:
       case 307:
         hops++


### PR DESCRIPTION
Adds `302 Found`, which is also used to redirect, i.e by https://google.com:

```
< HTTP/1.1 302 Found
< Cache-Control: private
< Content-Type: text/html; charset=UTF-8
< Location: https://www.google.de/?gfe_rd=cr&ei=qA6qVrPaIpPZ8AfpmYOYBQ
< Content-Length: 259
< Date: Thu, 28 Jan 2016 12:50:48 GMT
< Server: GFE/2.0
```

with this included in `http-traceroute`:

``` sh
$ http-traceroute https://google.com
[302] HEAD https://google.com (500 ms)
[200] HEAD https://www.google.de/?gfe_rd=cr&ei=pA-qVrz7Do3Z8AeDz4OoBQ (458 ms)
Trace finished in 961 ms using 1 hops
```
