### PR TITLE
Don't strip www subdomain from URLs when normalizing

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var hops = 0
 follow(process.argv[2], start)
 
 function follow (url, ms) {
-  url = normalizeUrl(url)
+  url = normalizeUrl(url, { stripWWW: false })
 
   if (url === prevUrl) {
     console.log('Self-referencing redirect detected - aborting...')


### PR DESCRIPTION
Disables stripping the `www` subdomain from URLs, because some sites redirect _to_ the `www` subdomain, for example `google.com`, leading to an endless loop of redirects:

```
[23:49:27] ~ $ http-traceroute http://google.com
  > original:  http://google.com
  > normal:    http://google.com
[302] HEAD http://google.com (72 ms)
  > original:  http://www.google.de/?gfe_rd=cr&ei=EL-7VrP-JaGF8QfH6riQDg
  > normal:    http://google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr
[302] HEAD http://google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr (105 ms)
  > original:  http://www.google.com/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr
  > normal:    http://google.com/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr
[302] HEAD http://google.com/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr (73 ms)
  > original:  http://www.google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr&gws_rd=cr
  > normal:    http://google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr&gws_rd=cr
[301] HEAD http://google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr&gws_rd=cr (70 ms)
  > original:  http://www.google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr&gws_rd=cr
  > normal:    http://google.de/?ei=EL-7VrP-JaGF8QfH6riQDg&gfe_rd=cr&gws_rd=cr
Self-referencing redirect detected - aborting...

[23:52:00] ~ $ http-traceroute http://google.com
  > original:  http://google.com
  > normal:    http://google.com
[302] HEAD http://google.com (62 ms)
  > original:  http://www.google.de/?gfe_rd=cr&ei=bb-7VqvcK6SF8QeTtrlA
  > normal:    http://www.google.de/?ei=bb-7VqvcK6SF8QeTtrlA&gfe_rd=cr
[200] HEAD http://www.google.de/?ei=bb-7VqvcK6SF8QeTtrlA&gfe_rd=cr (160 ms)
Trace finished in 224 ms using 1 hop
```
