### PR TITLE
Add cookie handling to support logins

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": "index.js",
   "dependencies": {
     "normalize-url": "^1.4.0",
-    "chalk": "^1.1.1"
+    "chalk": "^1.1.1",
+    "cookie-manager": "^0.0.16"
   },
   "devDependencies": {
     "standard": "^5.4.1"


### PR DESCRIPTION
Add a cookie store to enable handling "login" redirects, where a site reroutes through a cookie-setting URL to track or log in a client before redirecting back to the original URL.

Before:

``` sh
[23:59:50] ~ $ http-traceroute nyti.ms/1QETHgV
[301] HEAD http://nyti.ms/1QETHgV (310 ms)
[301] HEAD http://trib.al/CPCEesg (302 ms)
[301] HEAD http://nyti.ms/1Vsrnxp (247 ms)
[301] HEAD http://trib.al/YRVrqbr (250 ms)
[301] HEAD http://nyti.ms/1QDeeSW (249 ms)
[301] HEAD http://trib.al/HFpblHd (247 ms)
[301] HEAD http://nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&smtyp=cur (301 ms)
Self-referencing redirect detected - aborting...
```

Without self-referencing redirect prevention:

``` sh
[00:05:15] ~ $ http-traceroute nyti.ms/1QETHgV
[301] HEAD http://nyti.ms/1QETHgV (270 ms)
[301] HEAD http://trib.al/CPCEesg (310 ms)
[301] HEAD http://nyti.ms/1Vsrnxp (251 ms)
[301] HEAD http://trib.al/YRVrqbr (264 ms)
[301] HEAD http://nyti.ms/1QDeeSW (248 ms)
[301] HEAD http://trib.al/HFpblHd (253 ms)
[303] HEAD http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&smtyp=cur (304 ms)
[302] HEAD http://www.nytimes.com/glogin?URI=http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&smtyp=cur&_r=0 (261 ms)
[303] HEAD http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes (253 ms)
[302] HEAD http://www.nytimes.com/glogin?URI=http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&_r=0 (256 ms)
[303] HEAD http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes (256 ms)
[302] HEAD http://www.nytimes.com/glogin?URI=http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&_r=0 (260 ms)
...
```

With cookie handling (NOTE: doesn't quite work this way in this particular case without #3):

``` sh
[00:22:27] ~ $ http-traceroute nyti.ms/1QETHgV
[301] HEAD http://nyti.ms/1QETHgV (275 ms)
[301] HEAD http://trib.al/CPCEesg (289 ms)
[301] HEAD http://nyti.ms/1Vsrnxp (248 ms)
[301] HEAD http://trib.al/YRVrqbr (274 ms)
[301] HEAD http://nyti.ms/1QDeeSW (257 ms)
[301] HEAD http://trib.al/HFpblHd (254 ms)
[303] HEAD http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&smtyp=cur (300 ms)
[302] HEAD http://www.nytimes.com/glogin?URI=http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes&smtyp=cur&_r=0 (257 ms)
[200] HEAD http://www.nytimes.com/2016/01/27/nyregion/what-happened-to-jane-mayer-when-she-wrote-about-the-koch-brothers.html?smid=tw-nytimes (502 ms)
Trace finished in 2665 ms using 8 hops
```
