### PR TITLE
Spoof User-Agent header to circumvent abnormal routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var prevUrl
 var start = Date.now()
 var hops = 0
 var cookies = new Cookies()
+var userAgent = 'Mozilla/5.0 AppleWebKit/537.36 Chrome/50.0.2653.0 Safari/537.36'
 
 follow(process.argv[2], start)
 
@@ -36,7 +37,8 @@ function follow (url, ms) {
   var opts = parseUrl(url)
   opts.method = 'HEAD'
   opts.headers = {
-    Cookie: cookies.prepare(url)
+    'Cookie': cookies.prepare(url),
+    'User-Agent': userAgent
   }
 
   var protocol = opts.protocol === 'https:' ? https : http


### PR DESCRIPTION
Some sites redirect unsupported user agents to different routes, resulting in inaccurate traces.
Example:

``` sh
$ http-traceroute facebook.com
[302] HEAD http://facebook.com (257 ms)
[301] HEAD http://www.facebook.com/unsupportedbrowser (cookies: 1) (224 ms)
[200] HEAD https://www.facebook.com/unsupportedbrowser (cookies: 1) (324 ms)
Trace finished in 811 ms using 2 hops
```

With spoofed `User-Agent`:

``` sh
$ http-traceroute facebook.com
[301] HEAD http://facebook.com (312 ms)
[301] HEAD https://facebook.com (541 ms)
[200] HEAD https://www.facebook.com/?_rdr (cookies: 1) (396 ms)
Trace finished in 1257 ms using 2 hops
```
