### PR TITLE
Don't remove trailing slashes

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -76,7 +76,10 @@ Object.assign(Trace.prototype, {
   _follow: function (url, ms) {
     var self = this
 
-    this.currentUrl = normalizeUrl(url, { stripWWW: false })
+    this.currentUrl = normalizeUrl(url, {
+      stripWWW: false,
+      removeTrailingSlash: false
+    })
 
     if (this.currentUrl === this.prevUrl) {
       this.emit('error', new Error('Self-referencing redirect: ' + this.currentUrl))


### PR DESCRIPTION
When I try to trace the URL
http://fmi-wuerzburg.de,
it returns me an error "Self referencing redirect", because the URL has the following redirects:

http://fmi-wuerzburg.de 
=> https://fachschaft.informatik.uni-wuerzburg.de
=> https://fachschaft.informatik.uni-wuerzburg.de/wiki
=> https://fachschaft.informatik.uni-wuerzburg.de/wiki/

The last one seems to be a self reference to your module, because `normalize-url` removes the trailing slash by default.

My change has a config edit, so the trailing slash will not be removed.