### PR TITLE
use on() instead of once()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ trace.on('readable', function () {
   }
 })
 
-trace.once('error', function () {})
-trace.once('end', function () {})
+trace.on('error', function () {})
+trace.on('end', function () {})
 ```
 
 ## License


### PR DESCRIPTION
Hi, it's me again :)
I have got another improvement.

I changed the `once("error")` to `on("error")`, because I had the following issue:

My application crashed, whenever I tried to trace the URL `https://neu.bergwacht-wuerttemberg.de` which hasn't got a working certificate. I enclosed all things, which make requests, which an try-catch-block, but the app still crashed.
I started to remove single code blocks from my app, and in the end, the failure was in the http-traceroute code.
I reviewed your module code and saw the lines 
```javascript
req.on('error', function (error) {
      self.emit('error', error)
})
```

In my function call I changed once("error") to on("error"), and my app doesn't crash anymore.