### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "http-traceroute": "bin/cli.js"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
-    "cookie-manager": "^0.0.16",
+    "chalk": "^2.3.0",
+    "cookie-manager": "^0.0.19",
     "normalize-url": "^1.9.0",
-    "readable-stream": "^2.2.6",
+    "readable-stream": "^2.3.3",
     "spdy": "^3.4.4"
   },
   "devDependencies": {
     "standard": "^9.0.2",
-    "tape": "^4.6.3"
+    "tape": "^4.8.0"
   },
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
- chalk 1.1.3 -> 2.3.0
- cookie-manager 0.0.16 -> 0.0.19
- readable-stream 2.2.6 -> 2.3.3
- tape 4.6.3 -> 4.8.0